### PR TITLE
Include latest version with load

### DIFF
--- a/tree_test.go
+++ b/tree_test.go
@@ -300,7 +300,8 @@ func TestVersionedTree(t *testing.T) {
 	// Recreate a new tree and load it, to make sure it works in this
 	// scenario.
 	tree = NewVersionedTree(d, 100)
-	require.NoError(tree.Load())
+	_, err = tree.Load()
+	require.NoError(err)
 
 	require.Len(tree.versions, 2, "wrong number of versions")
 	require.EqualValues(v2, tree.Version())
@@ -345,7 +346,8 @@ func TestVersionedTree(t *testing.T) {
 	require.NotNil(hash4)
 
 	tree = NewVersionedTree(d, 100)
-	require.NoError(tree.Load())
+	_, err = tree.Load()
+	require.NoError(err)
 
 	// ------------
 	// DB UNCHANGED
@@ -553,7 +555,8 @@ func TestVersionedTreeSpecialCase2(t *testing.T) {
 	tree.SaveVersion()
 
 	tree = NewVersionedTree(d, 100)
-	require.NoError(tree.Load())
+	_, err := tree.Load()
+	require.NoError(err)
 
 	require.NoError(tree.DeleteVersion(2))
 

--- a/versioned_tree.go
+++ b/versioned_tree.go
@@ -71,6 +71,8 @@ func (tree *VersionedTree) Remove(key []byte) ([]byte, bool) {
 }
 
 // Load the latest versioned tree from disk.
+//
+// Returns the version number of the latest version found
 func (tree *VersionedTree) Load() (int64, error) {
 	return tree.LoadVersion(0)
 }

--- a/versioned_tree.go
+++ b/versioned_tree.go
@@ -70,22 +70,23 @@ func (tree *VersionedTree) Remove(key []byte) ([]byte, bool) {
 	return tree.orphaningTree.Remove(key)
 }
 
-// Load the latest versioned tree from disk. All tree versions are loaded automatically.
-func (tree *VersionedTree) Load() error {
+// Load the latest versioned tree from disk.
+func (tree *VersionedTree) Load() (int64, error) {
 	return tree.LoadVersion(0)
 }
 
-// Load a versioned tree from disk. All tree versions are loaded automatically.
+// Load a versioned tree from disk.
+//
 // If version is 0, the latest version is loaded.
-// NOTE: This function exists for the ABCI handshake.
-// TODO: Optimize this, why are we loading all the versions?!
-func (tree *VersionedTree) LoadVersion(targetVersion int64) error {
+//
+// Returns the version number of the latest version found
+func (tree *VersionedTree) LoadVersion(targetVersion int64) (int64, error) {
 	roots, err := tree.ndb.getRoots()
 	if err != nil {
-		return err
+		return 0, err
 	}
 	if len(roots) == 0 {
-		return nil
+		return 0, nil
 	}
 
 	// Load all roots from the database.
@@ -110,7 +111,7 @@ func (tree *VersionedTree) LoadVersion(targetVersion int64) error {
 
 	// Validate latestVersion
 	if !(targetVersion == 0 || latestVersion == targetVersion) {
-		return fmt.Errorf("Wanted to load target %v but only found up to %v",
+		return latestVersion, fmt.Errorf("Wanted to load target %v but only found up to %v",
 			targetVersion, latestVersion)
 	}
 
@@ -119,7 +120,7 @@ func (tree *VersionedTree) LoadVersion(targetVersion int64) error {
 		tree.versions[latestVersion].clone(),
 	)
 
-	return nil
+	return latestVersion, nil
 }
 
 // Rollback resets the working tree to the latest saved version, discarding


### PR DESCRIPTION
This simplifies our lives when attempting build an ABCI application using this as a backing store.